### PR TITLE
fix: URL is not defined

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -3,6 +3,7 @@ import { HelperLogger } from 'coc-helper';
 import { Uri, workspace } from 'coc.nvim';
 import fs from 'fs';
 import open from 'open';
+import { URL } from 'url';
 import util from 'util';
 
 export const config = workspace.getConfiguration('webview');


### PR DESCRIPTION
follow these steps 
![UL`GBQ7$7B`2KBY354BXUB8](https://user-images.githubusercontent.com/47070852/155725426-27b4bf9a-a149-43ea-a0fc-35b099a76305.png)
![K_5)G)E%53KUTRGUCWP~HQY](https://user-images.githubusercontent.com/47070852/155725436-cfae70fd-1883-4dc8-ae11-6d2cd804357d.png)
![P(WT8%6WQEL{~65C8GO}%UD](https://user-images.githubusercontent.com/47070852/155725463-eaa45bd6-32ed-491e-93b6-374e1b1e2bed.png)

It's weird. 

![URL](https://user-images.githubusercontent.com/47070852/155726219-5c438f8e-1e1c-4a2f-9ef4-668f8d68fd3e.gif)

I also tried the URL in my project and it says it's a global object, but it's not. Have no idea about it😂